### PR TITLE
Update formatter.py

### DIFF
--- a/codeformatter/formatter.py
+++ b/codeformatter/formatter.py
@@ -79,8 +79,5 @@ class Formatter:
 		return found.lower()
 
 	def clean(self, string):
-		if (self.st_version == 2):
-			mstr = string.decode('utf-8')
-		else:
-			mstr = string
+		mstr = string.decode('utf-8')
 		return re.sub(r'\r\n|\r', '\n', mstr)


### PR DESCRIPTION
fixed "re.sub can not use a string pattern on a bytes-like object" problem under sublime text 3 on OSX 10.8.4
