### PR TITLE
Added less files for CSS-Formatter

### DIFF
--- a/codeformatter/formatter.py
+++ b/codeformatter/formatter.py
@@ -37,6 +37,7 @@ class Formatter:
 			'json': JsFormatter,
 			'html': HtmlFormatter,
 			'css': CssFormatter,
+			'less': CssFormatter,
 			'python': PyFormatter
 		}
 		self.st_version = 2


### PR DESCRIPTION
This is a easy change to add less files to beautify. The parser doesn't work for less formatted files yet.
