### PR TITLE
Add Ruby language support

### DIFF
--- a/CodeFormatter.py
+++ b/CodeFormatter.py
@@ -35,7 +35,11 @@ cprint = globals()["__builtins__"]["print"]
 
 def plugin_loaded():
 	cprint('CodeFormatter: Plugin Initialized')
-
+	if (sublime.platform() != "windows"):
+		import stat
+		path = sublime.packages_path()+"/CodeFormatter/codeformatter/lib/phpbeautifier/php_beautifier"
+		st = os.stat(path)
+		os.chmod(path, st.st_mode | stat.S_IEXEC)
 
 if st_version == 2:
 	plugin_loaded()


### PR DESCRIPTION
Please help me!
I was used your CodeFormatter to format my code(php, css, js) and i feel your plugin was really sublime.
I use Sublime Text to develop my Ruby on Rails Application. So, I want add script to your plugin to support for Ruby language(or Rails framework). Can you help me?

Thank you so much!