### PR TITLE
Add PHP Transformations example file, fix minor spelling errors

### DIFF
--- a/CodeFormatter.sublime-settings
+++ b/CodeFormatter.sublime-settings
@@ -10,14 +10,14 @@
         "psr2": true, // Activate PSR2 style
         "indent_with_space": 4, // Use spaces instead of tabs for indentation
         "enable_auto_align": true, // Enable auto align of = and =>
-        "visibility_order": true, // Fixes visibiliy order for method in classes - PSR-2 4.2
+        "visibility_order": true, // Fixes visibility order for method in classes - PSR-2 4.2
         "smart_linebreak_after_curly": true, // Convert multistatement blocks into multiline blocks
 
-        // Enable specific transnformations. Example: ["ConvertOpenTagWithEcho", "PrettyPrintDocBlocks"]
-        // You can list all available transnformations from command palette: CodeFormatter: Show PHP Transformations
+        // Enable specific transformations. Example: ["ConvertOpenTagWithEcho", "PrettyPrintDocBlocks"]
+        // You can list all available transformations from command palette: CodeFormatter: Show PHP Transformations
         "passes": [],
 
-        // Disable specific transnformations
+        // Disable specific transformations
         "exclude": []
     },
 
@@ -36,8 +36,8 @@
         "e4x": false, // Pass E4X xml literals through untouched
         "jslint_happy": false, // if true, then jslint-stricter mode is enforced. Example function () vs function()
         "brace_style": "collapse", // "collapse" | "expand" | "end-expand". put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line.
-        "keep_array_indentation": false, // keep array identation.
-        "keep_function_indentation": false, // keep function identation.
+        "keep_array_indentation": false, // keep array indentation.
+        "keep_function_indentation": false, // keep function indentation.
         "eval_code": false, // eval code
         "unescape_strings": false, // Decode printable characters encoded in xNN notation
         "wrap_line_length": 0, // Wrap lines at next opportunity after N characters

--- a/PHP-Transformations.md
+++ b/PHP-Transformations.md
@@ -1,0 +1,1643 @@
+### AddMissingParentheses
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = new SomeClass;
+
+```
+</td>
+<td>
+```
+
+$a = new SomeClass();
+
+```
+</td>
+</tr>
+</table>
+
+
+### AliasToMaster
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = join(',', $arr);
+die("done");
+
+```
+</td>
+<td>
+```
+
+$a = implode(',', $arr);
+exit("done");
+
+```
+</td>
+</tr>
+</table>
+
+
+### AlignDoubleArrow
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = [
+  1 => 1,
+  22 => 22,
+  333 => 333,
+];
+
+```
+</td>
+<td>
+```
+
+$a = [
+  1   => 1,
+  22  => 22,
+  333 => 333,
+];
+
+```
+</td>
+</tr>
+</table>
+
+
+### AlignDoubleSlashComments
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+
+$a = 1; // Comment 1
+$bb = 22;  // Comment 2
+$ccc = 333;  // Comment 3
+
+```
+</td>
+<td>
+```
+
+$a = 1;      // Comment 1
+$bb = 22;    // Comment 2
+$ccc = 333;  // Comment 3
+
+```
+</td>
+</tr>
+</table>
+
+### AlignEquals
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = 1;
+$bb = 22;
+$ccc = 333;
+
+```
+</td>
+<td>
+```
+
+$a   = 1;
+$bb  = 22;
+$ccc = 333;
+
+```
+</td>
+</tr>
+</table>
+
+
+### AlignGroupDoubleArrow
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = [
+  1 => 1,
+  22 => 22,
+
+  333 => 333,
+  4444 => 4444,
+];
+
+```
+</td>
+<td>
+```
+
+$a = [
+  1  => 1,
+  22 => 22,
+
+  333  => 333,
+  4444 => 4444,
+];
+
+
+```
+</td>
+</tr>
+</table>
+
+
+### AlignTypehint
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+function a(
+  TypeA $a,
+  TypeBB $bb,
+  TypeCCC $ccc = array(),
+  TypeDDDD $dddd,
+  TypeEEEEE $eeeee
+){
+  noop();
+}
+
+```
+</td>
+<td>
+```
+
+function a(
+  TypeA     $a,
+  TypeBB    $bb,
+  TypeCCC   $ccc = array(),
+  TypeDDDD  $dddd,
+  TypeEEEEE $eeeee
+){
+  noop();
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### AllmanStyleBraces
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if ($a) {
+
+}
+
+```
+</td>
+<td>
+```
+
+if ($a)
+{
+
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### AutoSemicolon
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = new SomeClass()
+
+```
+</td>
+<td>
+```
+
+$a = new SomeClass();
+
+```
+</td>
+</tr>
+</table>
+
+
+### ClassToSelf
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+  const constant = 1;
+  function b(){
+    A::constant;
+  }
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  const constant = 1;
+  function b(){
+    self::constant;
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### ClassToStatic
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+  const constant = 1;
+  function b(){
+    A::constant;
+  }
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  const constant = 1;
+  function b(){
+    static::constant;
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### ConvertOpenTagWithEcho
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+<?="Hello World?>
+
+```
+</td>
+<td>
+```
+<?php echo "Hello World ?>
+
+```
+</td>
+</tr>
+</table>
+
+
+### DoubleToSingleQuote
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = "";
+
+```
+</td>
+<td>
+```
+
+$a = '';
+
+```
+</td>
+</tr>
+</table>
+
+
+### EncapsulateNamespaces
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+namespace NS1;
+class A {
+}
+
+```
+</td>
+<td>
+```
+
+namespace NS1 {
+  class A {
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### GeneratePHPDoc
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+  function a(Someclass $a) {
+    return 1;
+  }
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  /**
+   * @param Someclass $a
+   * @return int
+   */
+  function a(Someclass $a) {
+    return 1;
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### IndentTernaryConditions
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = ($b)
+? $c
+: $d
+;
+
+```
+</td>
+<td>
+```
+
+$a = ($b)
+  ? $c
+  : $d
+;
+
+```
+</td>
+</tr>
+</table>
+
+
+### JoinToImplode
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = join(',', $arr);
+
+```
+</td>
+<td>
+```
+
+$a = implode(',', $arr);
+
+```
+</td>
+</tr>
+</table>
+
+
+### LongArray
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = [$a, $b];
+
+```
+</td>
+<td>
+```
+
+$b = array($b, $c);
+
+```
+</td>
+</tr>
+</table>
+
+
+### MergeElseIf
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if($a){
+
+} else if($b) {
+
+}
+
+```
+</td>
+<td>
+```
+
+if($a){
+
+} elseif($b) {
+
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### MergeNamespaceWithOpenTag
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+<?php
+
+namespace A;
+?>
+```
+</td>
+<td>
+```
+<?php
+namespace A;
+?>
+```
+</td>
+</tr>
+</table>
+
+
+### NoSpaceAfterPHPDocBlocks
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+/**
+ * @param int $myInt
+ */
+
+function a($myInt){
+}
+
+```
+</td>
+<td>
+```
+
+/**
+ * @param int $myInt
+ */
+function a($myInt){
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### OnlyOrderUseClauses
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+use C;
+use B;
+
+class D {
+  function f() {
+    new B();
+  }
+}
+
+```
+</td>
+<td>
+```
+
+use B;
+use C;
+
+class D {
+  function f() {
+    new B();
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### OrderAndRemoveUseClauses
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+use C;
+use B;
+
+class D {
+  function f() {
+    new B();
+  }
+}
+
+```
+</td>
+<td>
+```
+
+use B;
+
+class D {
+  function f() {
+    new B();
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### OrganizeClass
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+  public function d(){}
+  protected function b(){}
+  private $a = "";
+  private function c(){}
+  public function a(){}
+  public $b = "";
+  const B = 0;
+  const A = 0;
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  const A = 0;
+
+  const B = 0;
+
+  public $b = "";
+
+  private $a = "";
+
+  public function a(){}
+
+  public function d(){}
+
+  protected function b(){}
+
+  private function c(){}
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### PHPDocTypesToFunctionTypehint
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+/**
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function abc($a = 10, $b = 20, $c) {
+
+}
+
+```
+</td>
+<td>
+```
+
+/**
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function abc(int $a = 10, int $b = 20, $c): int {
+
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### PrettyPrintDocBlocks
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+/**
+ * some description.
+ * @param array $b
+ * @param LongTypeName $c
+ */
+function A(array $b, LongTypeName $c) {
+}
+
+```
+</td>
+<td>
+```
+
+/**
+ * some description.
+ * @param array        $b
+ * @param LongTypeName $c
+ */
+function A(array $b, LongTypeName $c) {
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### PSR2EmptyFunction
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+// PSR2 Mode - From
+function a()
+{}
+
+```
+</td>
+<td>
+```
+
+function a() {}
+
+```
+</td>
+</tr>
+</table>
+
+
+### PSR2MultilineFunctionParams
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+function a($a, $b, $c)
+{}
+
+```
+</td>
+<td>
+```
+
+function a(
+  $a,
+  $b,
+  $c
+) {}
+
+```
+</td>
+</tr>
+</table>
+
+
+### ReindentAndAlignObjOps
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$aaaaa->b
+->c;
+
+```
+</td>
+<td>
+```
+
+$aaaaa->b
+      ->c;
+
+```
+</td>
+</tr>
+</table>
+
+
+### ReindentSwitchBlocks
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+switch ($a) {
+case 1:
+  echo 'a';
+}
+
+```
+</td>
+<td>
+```
+
+switch ($a) {
+  case 1:
+    echo 'a';
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### RemoveIncludeParentheses
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+require_once("file.php");
+
+```
+</td>
+<td>
+```
+
+require_once "file.php";
+
+```
+</td>
+</tr>
+</table>
+
+
+### RemoveSemicolonAfterCurly
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+function xxx() {
+    // code
+};
+
+```
+</td>
+<td>
+```
+
+function xxx() {
+    // code
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### RemoveUseLeadingSlash
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+namespace NS1;
+use \B;
+use \D;
+
+new B();
+new D();
+
+```
+</td>
+<td>
+```
+
+namespace NS1;
+use B;
+use D;
+
+new B();
+new D();
+
+```
+</td>
+</tr>
+</table>
+
+
+### ReplaceBooleanAndOr
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if ($a and $b or $c) {...}
+
+```
+</td>
+<td>
+```
+
+if ($a && $b || $c) {...}
+
+```
+</td>
+</tr>
+</table>
+
+
+### ReplaceIsNull
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+is_null($a);
+
+```
+</td>
+<td>
+```
+
+null === $a;
+
+```
+</td>
+</tr>
+</table>
+
+
+### ReturnNull
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+function a(){
+  return null;
+}
+
+```
+</td>
+<td>
+```
+
+function a(){
+  return;
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### ShortArray
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+echo array();
+
+```
+</td>
+<td>
+```
+
+echo [];
+
+```
+</td>
+</tr>
+</table>
+
+
+### SmartLnAfterCurlyOpen
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if($a) echo array();
+
+```
+</td>
+<td>
+```
+
+if($a) {
+  echo array();
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### SpaceAroundControlStructures
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if ($a) {
+
+}
+if ($b) {
+
+}
+
+```
+</td>
+<td>
+```
+
+if ($a) {
+
+}
+
+if ($b) {
+
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### SpaceAroundExclamationMark
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if (!true) foo();
+
+```
+</td>
+<td>
+```
+
+if ( ! true) foo();
+
+```
+</td>
+</tr>
+</table>
+
+
+### SpaceBetweenMethods
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+  function b(){
+
+  }
+  function c(){
+
+  }
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  function b(){
+
+  }
+
+  function c(){
+
+  }
+
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### SplitElseIf
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if($a){
+} elseif($b) {
+}
+
+```
+</td>
+<td>
+```
+
+if($a){
+} else if($b) {
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### StrictBehavior
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+array_search($needle, $haystack);
+base64_decode($str);
+in_array($needle, $haystack);
+
+array_keys($arr);
+mb_detect_encoding($arr);
+
+array_keys($arr, [1]);
+mb_detect_encoding($arr, 'UTF8');
+
+```
+</td>
+<td>
+```
+
+array_search($needle, $haystack, true);
+base64_decode($str, true);
+in_array($needle, $haystack, true);
+
+array_keys($arr, null, true);
+mb_detect_encoding($arr, null, true);
+
+array_keys($arr, [1], true);
+mb_detect_encoding($arr, 'UTF8', true);
+
+```
+</td>
+</tr>
+</table>
+
+
+### StrictComparison
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if($a == $b){}
+if($a != $b){}
+
+```
+</td>
+<td>
+```
+
+if($a === $b){}
+if($a !== $b){}
+
+```
+</td>
+</tr>
+</table>
+
+
+### StripExtraCommaInArray
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = [$a, $b, ];
+$b = array($b, $c, );
+
+```
+</td>
+<td>
+```
+
+$a = [$a, $b];
+$b = array($b, $c);
+
+```
+</td>
+</tr>
+</table>
+
+
+### StripNewlineAfterClassOpen
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+
+  protected $a;
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  protected $a;
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### StripNewlineAfterCurlyOpen
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+for ($a = 0; $a < 10; $a++){
+
+  if($a){
+
+    // do something
+  }
+}
+
+```
+</td>
+<td>
+```
+
+for ($a = 0; $a < 10; $a++){
+  if($a){
+    // do something
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### StripSpaces
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = [$a, $b];
+$b = array($b, $c);
+
+```
+</td>
+<td>
+```
+
+$a=[$a,$b];$b=array($b,$c);
+
+```
+</td>
+</tr>
+</table>
+
+
+### StripSpaceWithinControlStructures
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+for ($a = 0; $a < 10; $a++){
+
+  if($a){
+
+    // do something
+  }
+
+}
+
+```
+</td>
+<td>
+```
+
+for ($a = 0; $a < 10; $a++){
+  if($a){
+    // do something
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### TightConcat
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$a = 'a' . 'b';
+$a = 'a' . 1 . 'b';
+
+```
+</td>
+<td>
+```
+
+$a = 'a'.'b';
+$a = 'a'. 1 .'b';
+
+```
+</td>
+</tr>
+</table>
+
+
+### UpgradeToPreg
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+$var = ereg("[A-Z]", $var);
+$var = eregi_replace("[A-Z]", "", $var)
+$var = spliti("[A-Z]", $var);
+
+```
+</td>
+<td>
+```
+
+$var = preg_match("/[A-Z]/Di", $var);
+$var = preg_replace("/[A-Z]/Di", "", $var);
+$var = preg_split("/[A-Z]/Di", $var);
+
+```
+</td>
+</tr>
+</table>
+
+
+### WrongConstructorName
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+class A {
+  function A(){
+
+  }
+}
+
+```
+</td>
+<td>
+```
+
+class A {
+  function __construct(){
+
+  }
+}
+
+```
+</td>
+</tr>
+</table>
+
+
+### YodaComparisons
+<table>
+<tr>
+<td>Before</td>
+<td>After</td>
+</tr>
+<tr>
+<td>
+```
+
+if($a == 1){
+
+}
+
+```
+</td>
+<td>
+```
+
+if(1 == $a){
+
+}
+
+```
+</td>
+</tr>
+</table>

--- a/PHP-Transformations.md
+++ b/PHP-Transformations.md
@@ -346,26 +346,14 @@ class A {
 
 
 ### ConvertOpenTagWithEcho
-<table>
-<tr>
-<td>Before</td>
-<td>After</td>
-</tr>
-<tr>
-<td>
-<pre>
-<?="Hello World?>
 
-</pre>
-</td>
-<td>
-<pre>
-<?php echo "Hello World ?>
+##### Before
 
-</pre>
-</td>
-</tr>
-</table>
+`<?="Hello World?>`
+
+##### After
+
+`<?php echo "Hello World ?>`
 
 
 ### DoubleToSingleQuote
@@ -575,29 +563,23 @@ if($a){
 
 
 ### MergeNamespaceWithOpenTag
-<table>
-<tr>
-<td>Before</td>
-<td>After</td>
-</tr>
-<tr>
-<td>
-<pre>
+
+##### Before
+
+```
 <?php
 
 namespace A;
 ?>
-</pre>
-</td>
-<td>
-<pre>
+```
+
+##### After
+
+```
 <?php
 namespace A;
 ?>
-</pre>
-</td>
-</tr>
-</table>
+```
 
 
 ### NoSpaceAfterPHPDocBlocks

--- a/PHP-Transformations.md
+++ b/PHP-Transformations.md
@@ -6,18 +6,18 @@
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = new SomeClass;
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = new SomeClass();
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -31,20 +31,20 @@ $a = new SomeClass();
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = join(',', $arr);
 die("done");
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = implode(',', $arr);
 exit("done");
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -58,7 +58,7 @@ exit("done");
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = [
   1 => 1,
@@ -66,10 +66,10 @@ $a = [
   333 => 333,
 ];
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = [
   1   => 1,
@@ -77,7 +77,7 @@ $a = [
   333 => 333,
 ];
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -91,23 +91,23 @@ $a = [
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 
 $a = 1; // Comment 1
 $bb = 22;  // Comment 2
 $ccc = 333;  // Comment 3
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = 1;      // Comment 1
 $bb = 22;    // Comment 2
 $ccc = 333;  // Comment 3
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -120,22 +120,22 @@ $ccc = 333;  // Comment 3
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = 1;
 $bb = 22;
 $ccc = 333;
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a   = 1;
 $bb  = 22;
 $ccc = 333;
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -149,7 +149,7 @@ $ccc = 333;
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = [
   1 => 1,
@@ -159,10 +159,10 @@ $a = [
   4444 => 4444,
 ];
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = [
   1  => 1,
@@ -173,7 +173,7 @@ $a = [
 ];
 
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -187,7 +187,7 @@ $a = [
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 function a(
   TypeA $a,
@@ -199,10 +199,10 @@ function a(
   noop();
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 function a(
   TypeA     $a,
@@ -214,7 +214,7 @@ function a(
   noop();
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -228,23 +228,23 @@ function a(
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if ($a) {
 
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if ($a)
 {
 
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -258,18 +258,18 @@ if ($a)
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = new SomeClass()
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = new SomeClass();
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -283,7 +283,7 @@ $a = new SomeClass();
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
   const constant = 1;
@@ -292,10 +292,10 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   const constant = 1;
@@ -304,7 +304,7 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -318,7 +318,7 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
   const constant = 1;
@@ -327,10 +327,10 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   const constant = 1;
@@ -339,7 +339,7 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -353,16 +353,16 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 <?="Hello World?>
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 <?php echo "Hello World ?>
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -376,18 +376,18 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = "";
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = '';
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -401,23 +401,23 @@ $a = '';
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 namespace NS1;
 class A {
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 namespace NS1 {
   class A {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -431,7 +431,7 @@ namespace NS1 {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
   function a(Someclass $a) {
@@ -439,10 +439,10 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   /**
@@ -454,7 +454,7 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -468,24 +468,24 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = ($b)
 ? $c
 : $d
 ;
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = ($b)
   ? $c
   : $d
 ;
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -499,18 +499,18 @@ $a = ($b)
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = join(',', $arr);
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = implode(',', $arr);
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -524,18 +524,18 @@ $a = implode(',', $arr);
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = [$a, $b];
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $b = array($b, $c);
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -549,7 +549,7 @@ $b = array($b, $c);
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if($a){
 
@@ -557,10 +557,10 @@ if($a){
 
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if($a){
 
@@ -568,7 +568,7 @@ if($a){
 
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -582,19 +582,19 @@ if($a){
 </tr>
 <tr>
 <td>
-```
+<pre>
 <?php
 
 namespace A;
 ?>
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 <?php
 namespace A;
 ?>
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -608,7 +608,7 @@ namespace A;
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 /**
  * @param int $myInt
@@ -617,10 +617,10 @@ namespace A;
 function a($myInt){
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 /**
  * @param int $myInt
@@ -628,7 +628,7 @@ function a($myInt){
 function a($myInt){
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -642,7 +642,7 @@ function a($myInt){
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 use C;
 use B;
@@ -653,10 +653,10 @@ class D {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 use B;
 use C;
@@ -667,7 +667,7 @@ class D {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -681,7 +681,7 @@ class D {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 use C;
 use B;
@@ -692,10 +692,10 @@ class D {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 use B;
 
@@ -705,7 +705,7 @@ class D {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -719,7 +719,7 @@ class D {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
   public function d(){}
@@ -732,10 +732,10 @@ class A {
   const A = 0;
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   const A = 0;
@@ -755,7 +755,7 @@ class A {
   private function c(){}
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -769,7 +769,7 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 /**
  * @param int $a
@@ -780,10 +780,10 @@ function abc($a = 10, $b = 20, $c) {
 
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 /**
  * @param int $a
@@ -794,7 +794,7 @@ function abc(int $a = 10, int $b = 20, $c): int {
 
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -808,7 +808,7 @@ function abc(int $a = 10, int $b = 20, $c): int {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 /**
  * some description.
@@ -818,10 +818,10 @@ function abc(int $a = 10, int $b = 20, $c): int {
 function A(array $b, LongTypeName $c) {
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 /**
  * some description.
@@ -831,7 +831,7 @@ function A(array $b, LongTypeName $c) {
 function A(array $b, LongTypeName $c) {
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -845,20 +845,20 @@ function A(array $b, LongTypeName $c) {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 // PSR2 Mode - From
 function a()
 {}
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 function a() {}
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -872,15 +872,15 @@ function a() {}
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 function a($a, $b, $c)
 {}
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 function a(
   $a,
@@ -888,7 +888,7 @@ function a(
   $c
 ) {}
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -902,20 +902,20 @@ function a(
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $aaaaa->b
 ->c;
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $aaaaa->b
       ->c;
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -929,24 +929,24 @@ $aaaaa->b
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 switch ($a) {
 case 1:
   echo 'a';
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 switch ($a) {
   case 1:
     echo 'a';
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -960,18 +960,18 @@ switch ($a) {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 require_once("file.php");
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 require_once "file.php";
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -985,22 +985,22 @@ require_once "file.php";
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 function xxx() {
     // code
 };
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 function xxx() {
     // code
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1014,7 +1014,7 @@ function xxx() {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 namespace NS1;
 use \B;
@@ -1023,10 +1023,10 @@ use \D;
 new B();
 new D();
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 namespace NS1;
 use B;
@@ -1035,7 +1035,7 @@ use D;
 new B();
 new D();
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1049,18 +1049,18 @@ new D();
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if ($a and $b or $c) {...}
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if ($a && $b || $c) {...}
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1074,18 +1074,18 @@ if ($a && $b || $c) {...}
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 is_null($a);
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 null === $a;
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1099,22 +1099,22 @@ null === $a;
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 function a(){
   return null;
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 function a(){
   return;
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1128,18 +1128,18 @@ function a(){
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 echo array();
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 echo [];
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1153,20 +1153,20 @@ echo [];
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if($a) echo array();
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if($a) {
   echo array();
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1180,7 +1180,7 @@ if($a) {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if ($a) {
 
@@ -1189,10 +1189,10 @@ if ($b) {
 
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if ($a) {
 
@@ -1202,7 +1202,7 @@ if ($b) {
 
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1216,18 +1216,18 @@ if ($b) {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if (!true) foo();
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if ( ! true) foo();
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1241,7 +1241,7 @@ if ( ! true) foo();
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
   function b(){
@@ -1252,10 +1252,10 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   function b(){
@@ -1268,7 +1268,7 @@ class A {
 
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1282,22 +1282,22 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if($a){
 } elseif($b) {
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if($a){
 } else if($b) {
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1311,7 +1311,7 @@ if($a){
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 array_search($needle, $haystack);
 base64_decode($str);
@@ -1323,10 +1323,10 @@ mb_detect_encoding($arr);
 array_keys($arr, [1]);
 mb_detect_encoding($arr, 'UTF8');
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 array_search($needle, $haystack, true);
 base64_decode($str, true);
@@ -1338,7 +1338,7 @@ mb_detect_encoding($arr, null, true);
 array_keys($arr, [1], true);
 mb_detect_encoding($arr, 'UTF8', true);
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1352,20 +1352,20 @@ mb_detect_encoding($arr, 'UTF8', true);
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if($a == $b){}
 if($a != $b){}
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if($a === $b){}
 if($a !== $b){}
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1379,20 +1379,20 @@ if($a !== $b){}
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = [$a, $b, ];
 $b = array($b, $c, );
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = [$a, $b];
 $b = array($b, $c);
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1406,23 +1406,23 @@ $b = array($b, $c);
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
 
   protected $a;
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   protected $a;
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1436,7 +1436,7 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 for ($a = 0; $a < 10; $a++){
 
@@ -1446,10 +1446,10 @@ for ($a = 0; $a < 10; $a++){
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 for ($a = 0; $a < 10; $a++){
   if($a){
@@ -1457,7 +1457,7 @@ for ($a = 0; $a < 10; $a++){
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1471,19 +1471,19 @@ for ($a = 0; $a < 10; $a++){
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = [$a, $b];
 $b = array($b, $c);
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a=[$a,$b];$b=array($b,$c);
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1497,7 +1497,7 @@ $a=[$a,$b];$b=array($b,$c);
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 for ($a = 0; $a < 10; $a++){
 
@@ -1508,10 +1508,10 @@ for ($a = 0; $a < 10; $a++){
 
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 for ($a = 0; $a < 10; $a++){
   if($a){
@@ -1519,7 +1519,7 @@ for ($a = 0; $a < 10; $a++){
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1533,20 +1533,20 @@ for ($a = 0; $a < 10; $a++){
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $a = 'a' . 'b';
 $a = 'a' . 1 . 'b';
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $a = 'a'.'b';
 $a = 'a'. 1 .'b';
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1560,22 +1560,22 @@ $a = 'a'. 1 .'b';
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 $var = ereg("[A-Z]", $var);
 $var = eregi_replace("[A-Z]", "", $var)
 $var = spliti("[A-Z]", $var);
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 $var = preg_match("/[A-Z]/Di", $var);
 $var = preg_replace("/[A-Z]/Di", "", $var);
 $var = preg_split("/[A-Z]/Di", $var);
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1589,7 +1589,7 @@ $var = preg_split("/[A-Z]/Di", $var);
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 class A {
   function A(){
@@ -1597,10 +1597,10 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 class A {
   function __construct(){
@@ -1608,7 +1608,7 @@ class A {
   }
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>
@@ -1622,22 +1622,22 @@ class A {
 </tr>
 <tr>
 <td>
-```
+<pre>
 
 if($a == 1){
 
 }
 
-```
+</pre>
 </td>
 <td>
-```
+<pre>
 
 if(1 == $a){
 
 }
 
-```
+</pre>
 </td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ On Linux/OSx after installation of package, you must set chmod +x to file fmt.ph
 
 You can list all available transformations from Command Palette: CodeFormatter: Show PHP Transformations
 
+Examples of many transformations can be found here: [PHP Transformation Examples](https://github.com/akalongman/sublimetext-codeformatter/blob/master/PHP-Transformations.md)
+
 Language specific options:
 ```js
    "codeformatter_php_options":
@@ -81,11 +83,12 @@ Language specific options:
         "psr2": true, // Activate PSR2 style
         "indent_with_space": 4, // Use spaces instead of tabs for indentation
         "enable_auto_align": true, // Enable auto align of = and =>
-        "visibility_order": true, // Fixes visibiliy order for method in classes - PSR-2 4.2
+        "visibility_order": true, // Fixes visibility order for method in classes - PSR-2 4.2
         "smart_linebreak_after_curly": true, // Convert multistatement blocks into multiline blocks
 
         // Enable specific transformations. Example: ["ConvertOpenTagWithEcho", "PrettyPrintDocBlocks"]
         // You can list all available transformations from command palette: CodeFormatter: Show PHP Transformations
+        // You can also see examples of many transformations at https://github.com/akalongman/sublimetext-codeformatter/blob/master/PHP-Transformations.md
         "passes": [],
 
         // Disable specific transformations
@@ -115,8 +118,8 @@ Language specific options:
         "e4x": false, // Pass E4X xml literals through untouched
         "jslint_happy": false, // if true, then jslint-stricter mode is enforced. Example function () vs function()
         "brace_style": "collapse", // "collapse" | "expand" | "end-expand". put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line.
-        "keep_array_indentation": false, // keep array identation.
-        "keep_function_indentation": false, // keep function identation.
+        "keep_array_indentation": false, // keep array indentation.
+        "keep_function_indentation": false, // keep function indentation.
         "eval_code": false, // eval code
         "unescape_strings": false, // Decode printable characters encoded in xNN notation
         "wrap_line_length": 0, // Wrap lines at next opportunity after N characters


### PR DESCRIPTION
I've compiled the example code snippets from inside the source code of `phpfmt`'s transformations ([in this directory](https://github.com/phpfmt/fmt/tree/master/src/Additionals)) into one markdown document for reference.

Also added are references to this new document in `README.md` and the default settings file `CodeFormatter.sublime-settings`