### PR TITLE
Allowing format_on_save option to be a regex (matching the file_name)

### DIFF
--- a/CodeFormatter.sublime-settings
+++ b/CodeFormatter.sublime-settings
@@ -5,7 +5,7 @@
     {
         "syntaxes": "php", // Syntax names which must process PHP formatter
         "php_path": "", // Path for PHP executable, e.g. "/usr/lib/php" or "C:/Program Files/PHP/php.exe". If empty, uses command "php" from system environments
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "php55_compat": false, // PHP 5.5 compatible mode
         "psr1": false, // Activate PSR1 style
         "psr1_naming": false, // Activate PSR1 style - Section 3 and 4.3 - Class and method names case
@@ -26,7 +26,7 @@
     "codeformatter_js_options":
     {
         "syntaxes": "javascript,json", // Syntax names which must process JS formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 4, // indentation size
         "indent_char": " ", // Indent character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
@@ -52,7 +52,7 @@
     "codeformatter_css_options":
     {
         "syntaxes": "css,less", // Syntax names which must process CSS formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 4, // Indentation size
         "indent_char": " ", // Indentation character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
@@ -65,7 +65,7 @@
 	"codeformatter_scss_options":
 	{
         "syntaxes": "scss", // Indentation size
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
 		"indent_size": 2, // Indentation size
 		"indent_char": " ", // Indentation character
 		"indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
@@ -76,7 +76,7 @@
     "codeformatter_html_options":
     {
         "syntaxes": "html,blade,asp,xml", // Syntax names which must process HTML formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "formatter_version": "bs4", // Which formatter to use. Current options are "bs4" and "regexp". If an error occurs while loading the bs4 formatter, the regexp formatter will automatically be used
         "indent_size": 4, // indentation size
         "indent_char": " ", // Indentation character
@@ -94,7 +94,7 @@
     "codeformatter_python_options":
     {
         "syntaxes": "python", // Syntax names which must process Python formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 1, // indentation size
         "indent_with_tabs": true, // Indent with tabs or spaces
         "max_char": 80, // Width of output lines in characters.
@@ -154,7 +154,7 @@
     "codeformatter_vbscript_options":
     {
         "syntaxes": "vbscript", // Syntax names which must process VBScript formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 1, // indentation size
         "indent_char": "\t", // Indentation character
         "indent_with_tabs": true, // Indent with one tab (overrides indent_size and indent_char options)
@@ -168,7 +168,7 @@
     "codeformatter_coldfusion_options":
     {
         "syntaxes": "coldfusion,cfm,cfml", // Syntax names which must process Coldfusion Markup Language formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 2, // indentation size
         "indent_char": " ", // Indentation character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)

--- a/CodeFormatter.sublime-settings
+++ b/CodeFormatter.sublime-settings
@@ -87,6 +87,7 @@
         "minimum_attribute_count": 2, // Minimum number of attributes needed before tag attributes are expanded to new lines
         "first_attribute_on_new_line": false, // Put all attributes on separate lines from the tag (only uses 1 indentation unit as opposed to lining all attributes up with the first)
         "reduce_empty_tags": false, // Put closing tags on same line as opening tag if there is no content between them
+        "reduce_whole_word_tags": false, // Put closing tags on same line as opening tag if there is whole word between them
         "custom_singletons": "" // Custom singleton tags for various template languages outside of the HTML5 spec
     },
 
@@ -178,6 +179,7 @@
         "minimum_attribute_count": 2, // Minimum number of attributes needed before tag attributes are expanded to new lines
         "first_attribute_on_new_line": false, // Put all attributes on separate lines from the tag (only uses 1 indentation unit as opposed to lining all attributes up with the first)
         "reduce_empty_tags": false, // Put closing tags on same line as opening tag if there is no content between them
+        "reduce_whole_word_tags": false, // Put closing tags on same line as opening tag if there is whole word between them
         "custom_singletons": "" // Custom singleton tags for various template languages outside of the HTML5 spec
     }
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Language specific options:
         "minimum_attribute_count": 2, // Minimum number of attributes needed before tag attributes are expanded to new lines
         "first_attribute_on_new_line": false, // Put all attributes on separate lines from the tag (only uses 1 indentation unit as opposed to lining all attributes up with the first)
         "reduce_empty_tags": false, // Put closing tags on same line as opening tag if there is no content between them
+        "reduce_whole_word_tags": false, // Put closing tags on same line as opening tag if there is whole word between them
         "custom_singletons": "" // Custom singleton tags for various template languages outside of the HTML5 spec
     }
 ```
@@ -288,6 +289,7 @@ Language specific options:
         "minimum_attribute_count": 2, // Minimum number of attributes needed before tag attributes are expanded to new lines
         "first_attribute_on_new_line": false // Put all attributes on separate lines from the tag (only uses 1 indentation unit as opposed to lining all attributes up with the first)
         "reduce_empty_tags": false, // Put closing tags on same line as opening tag if there is no content between them
+        "reduce_whole_word_tags": false, // Put closing tags on same line as opening tag if there is whole word between them
         "custom_singletons": "" // Custom singleton tags for various template languages outside of the HTML5 spec
     }
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Language specific options:
     {
         "syntaxes": "php", // Syntax names which must process PHP formatter
         "php_path": "", // Path for PHP executable, e.g. "/usr/lib/php" or "C:/Program Files/PHP/php.exe". If empty, uses command "php" from system environments
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "psr1": false, // Activate PSR1 style
         "psr1_naming": false, // Activate PSR1 style - Section 3 and 4.3 - Class and method names case
         "psr2": true, // Activate PSR2 style
@@ -106,7 +106,7 @@ Language specific options:
     "codeformatter_js_options":
     {
         "syntaxes": "javascript,json", // Syntax names which must process JS formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 4, // indentation size
         "indent_char": " ", // Indent character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
@@ -137,7 +137,7 @@ Language specific options:
     "codeformatter_html_options":
     {
         "syntaxes": "html,asp,xml", // Syntax names which must process HTML formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 4, // indentation size
         "indent_char": " ", // Indentation character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
@@ -159,7 +159,7 @@ Language specific options:
     "codeformatter_css_options":
     {
         "syntaxes": "css,less", // Syntax names which must process CSS formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 4, // Indentation size
         "indent_char": " ", // Indentation character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
@@ -178,7 +178,7 @@ Language specific options:
     {
         "syntaxes": "scss", // Indentation size
         "indent_size": 2, // Indentation size
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_char": " ", // Indentation character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
         "selector_separator_newline": true, // Add new lines after selector separators
@@ -194,7 +194,7 @@ Language specific options:
     "codeformatter_python_options":
     {
         "syntaxes": "python", // Syntax names which must process Python formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 1, // indentation size
         "indent_with_tabs": true, // Indent with tabs or spaces
         "max_char": 80, // Width of output lines in characters.
@@ -259,7 +259,7 @@ Language specific options:
     "codeformatter_vbscript_options":
     {
         "syntaxes": "vbscript", // Syntax names which must process VBScript formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 1, // indentation size
         "indent_char": "\t", // Indentation character
         "indent_with_tabs": true, // Indent with one tab (overrides indent_size and indent_char options)
@@ -278,7 +278,7 @@ Language specific options:
     "codeformatter_coldfusion_options":
     {
         "syntaxes": "coldfusion,cfm,cfml", // Syntax names which must process Coldfusion Markup Language formatter
-        "format_on_save": false, // Format on save
+        "format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
         "indent_size": 2, // indentation size
         "indent_char": " ", // Indentation character
         "indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)

--- a/codeformatter/coldfusionformatter.py
+++ b/codeformatter/coldfusionformatter.py
@@ -47,6 +47,9 @@ class ColdfusionFormatter:
         if "reduce_empty_tags" in self.opts:
             options.reduce_empty_tags = self.opts["reduce_empty_tags"]
 
+        if "reduce_whole_word_tags" in self.opts:
+            options.reduce_whole_word_tags = self.opts["reduce_whole_word_tags"]
+
         if "exception_on_tag_mismatch" in self.opts:
             options.exception_on_tag_mismatch = self.opts["exception_on_tag_mismatch"]
 

--- a/codeformatter/coldfusionformatter.py
+++ b/codeformatter/coldfusionformatter.py
@@ -63,8 +63,10 @@ class ColdfusionFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save

--- a/codeformatter/cssformatter.py
+++ b/codeformatter/cssformatter.py
@@ -66,10 +66,12 @@ class CssFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save
 
 

--- a/codeformatter/formatter.py
+++ b/codeformatter/formatter.py
@@ -80,6 +80,7 @@ class Formatter:
 
         # Python
         opts = self.settings.get('codeformatter_python_options')
+        print(opts)
         if ("syntaxes" in opts and opts["syntaxes"]):
             for _formatter in opts["syntaxes"].split(","):
                 self.classmap[_formatter.strip()] = PyFormatter

--- a/codeformatter/formatter.py
+++ b/codeformatter/formatter.py
@@ -139,7 +139,7 @@ class Formatter:
         if (not self.exists()):
             return False
         formatter = self.classmap[self.syntax](self)
-        return formatter.formatOnSaveEnabled()
+        return formatter.formatOnSaveEnabled(self.file_name)
 
 
 

--- a/codeformatter/htmlformatter.py
+++ b/codeformatter/htmlformatter.py
@@ -92,8 +92,10 @@ class HtmlFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save

--- a/codeformatter/htmlformatter.py
+++ b/codeformatter/htmlformatter.py
@@ -15,7 +15,7 @@ libs_path = os.path.join(libs_path, "htmlbeautifier")
 
 if libs_path not in sys.path:
     sys.path.append(libs_path)
-    
+
 import htmlbeautifier
 use_bs4 = True
 try:
@@ -75,6 +75,9 @@ class HtmlFormatter:
 
             if "reduce_empty_tags" in self.opts:
                 options.reduce_empty_tags = self.opts["reduce_empty_tags"]
+
+            if "reduce_whole_word_tags" in self.opts:
+                options.reduce_whole_word_tags = self.opts["reduce_whole_word_tags"]
 
             if "exception_on_tag_mismatch" in self.opts:
                 options.exception_on_tag_mismatch = self.opts["exception_on_tag_mismatch"]

--- a/codeformatter/jsformatter.py
+++ b/codeformatter/jsformatter.py
@@ -151,10 +151,12 @@ class JsFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save
 
 

--- a/codeformatter/lib/coldfusionbeautifier/__init__.py
+++ b/codeformatter/lib/coldfusionbeautifier/__init__.py
@@ -19,6 +19,7 @@ class BeautifierOptions:
         self.minimum_attribute_count = 2
         self.first_attribute_on_new_line = False
         self.reduce_empty_tags = False
+        self.reduce_whole_word_tags = False
         self.exception_on_tag_mismatch = False
         self.custom_singletons = ''
 
@@ -30,8 +31,9 @@ expand_tags = [%s]
 minimum_attribute_count = %d
 first_attribute_on_new_line = [%s]
 reduce_empty_tags = [%s]
+reduce_whole_word_tags = [%s]
 exception_on_tag_mismatch = [%s]
-custom_singletons = [%s]""" % (self.indent_size, self.indent_char, self.indent_with_tabs, self.expand_tags, self.minimum_attribute_count, self.first_attribute_on_new_line, self.reduce_empty_tags, self.exception_on_tag_mismatch, self.custom_singletons)
+custom_singletons = [%s]""" % (self.indent_size, self.indent_char, self.indent_with_tabs, self.expand_tags, self.minimum_attribute_count, self.first_attribute_on_new_line, self.reduce_empty_tags, self.reduce_whole_word_tags, self.exception_on_tag_mismatch, self.custom_singletons)
 
 def default_options():
     return BeautifierOptions()
@@ -65,6 +67,7 @@ class Beautifier:
         self.minimum_attribute_count = opts.minimum_attribute_count
         self.first_attribute_on_new_line = opts.first_attribute_on_new_line
         self.reduce_empty_tags = opts.reduce_empty_tags
+        self.reduce_whole_word_tags = opts.reduce_whole_word_tags
         self.indent_size = opts.indent_size
         self.indent_char = opts.indent_char
         self.indent_with_tabs = opts.indent_with_tabs
@@ -203,6 +206,8 @@ class Beautifier:
         # Put all matched start/end tags with no content between them on the same line and return
         if self.reduce_empty_tags:
             beautiful = re.sub(r'<(\S+)([^>]*)>\s+</\1>',r'<\1\2></\1>',beautiful)
+        if self.reduce_whole_word_tags:
+            beautiful = re.sub(r'<(\S+)([^>]*)>\s+([^<\n]+)\s+</\1>',r'<\1\2>\3</\1>',beautiful)
 
         # Replace JS, CSS, and comments in the opposite order of their removal
         beautiful = self.replace_comments(beautiful)

--- a/codeformatter/lib/htmlbeautifier/__init__.py
+++ b/codeformatter/lib/htmlbeautifier/__init__.py
@@ -5,10 +5,10 @@ import sys
 import re
 import sublime
 try:
- 	# Python 3
+	# Python 3
 	from .__version__ import __version__
 except (ValueError):
- 	# Python 2
+	# Python 2
 	from __version__ import __version__
 
 class BeautifierOptions:
@@ -20,6 +20,7 @@ class BeautifierOptions:
 		self.minimum_attribute_count = 2
 		self.first_attribute_on_new_line = False
 		self.reduce_empty_tags = False
+		self.reduce_whole_word_tags = False
 		self.exception_on_tag_mismatch = False
 		self.custom_singletons = ''
 
@@ -31,8 +32,9 @@ expand_tags = [%s]
 minimum_attribute_count = %d
 first_attribute_on_new_line = [%s]
 reduce_empty_tags = [%s]
+reduce_whole_word_tags = [%s]
 exception_on_tag_mismatch = [%s]
-custom_singletons = [%s]""" % (self.indent_size, self.indent_char, self.indent_with_tabs, self.expand_tags, self.minimum_attribute_count, self.first_attribute_on_new_line, self.reduce_empty_tags, self.exception_on_tag_mismatch, self.custom_singletons)
+custom_singletons = [%s]""" % (self.indent_size, self.indent_char, self.indent_with_tabs, self.expand_tags, self.minimum_attribute_count, self.first_attribute_on_new_line, self.reduce_empty_tags, self.reduce_whole_word_tags, self.exception_on_tag_mismatch, self.custom_singletons)
 
 def default_options():
 	return BeautifierOptions()
@@ -65,6 +67,7 @@ class Beautifier:
 		self.minimum_attribute_count = opts.minimum_attribute_count
 		self.first_attribute_on_new_line = opts.first_attribute_on_new_line
 		self.reduce_empty_tags = opts.reduce_empty_tags
+		self.reduce_whole_word_tags = opts.reduce_whole_word_tags
 		self.indent_size = opts.indent_size
 		self.indent_char = opts.indent_char
 		self.indent_with_tabs = opts.indent_with_tabs
@@ -201,6 +204,9 @@ class Beautifier:
 		# Put all matched start/end tags with no content between them on the same line and return
 		if self.reduce_empty_tags:
 			beautiful = re.sub(r'<(\S+)([^>]*)>\s+</\1>',r'<\1\2></\1>',beautiful)
+		# Put all matched start/end tags with whole_word content between them on the same line and return
+		if self.reduce_whole_word_tags:
+			beautiful = re.sub(r'<(\S+)([^>]*)>\s+([^<\n]+)\s+</\1>',r'<\1\2>\3</\1>',beautiful)
 
 		# Replace JS, CSS, and comments in the opposite order of their removal
 		beautiful = self.replace_comments(beautiful)

--- a/codeformatter/phpformatter.py
+++ b/codeformatter/phpformatter.py
@@ -136,8 +136,10 @@ class PhpFormatter:
 
 
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save

--- a/codeformatter/pyformatter.py
+++ b/codeformatter/pyformatter.py
@@ -293,8 +293,10 @@ class PyFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save

--- a/codeformatter/scssformatter.py
+++ b/codeformatter/scssformatter.py
@@ -63,10 +63,12 @@ class ScssFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save
 
 

--- a/codeformatter/vbscriptformatter.py
+++ b/codeformatter/vbscriptformatter.py
@@ -70,10 +70,12 @@ class VbscriptFormatter:
 
         return stdout, stderr
 
-    def formatOnSaveEnabled(self):
+    def formatOnSaveEnabled(self, file_name):
         format_on_save = False
         if ("format_on_save" in self.opts and self.opts["format_on_save"]):
             format_on_save = self.opts["format_on_save"]
+        if (isinstance(format_on_save, str)):
+            format_on_save = re.search(format_on_save, file_name) != None
         return format_on_save
 
 


### PR DESCRIPTION
Using "^((?!vendor).)*$" as value for format_on_save parameter permits me to ignore format on save option for files in vendor directory
