### PR TITLE
Fixes the --excludes part of the command for phpfmt

### DIFF
--- a/CodeFormatter.sublime-settings
+++ b/CodeFormatter.sublime-settings
@@ -20,7 +20,7 @@
         "passes": [],
 
         // Disable specific transformations
-        "exclude": []
+        "excludes": []
     },
 
     "codeformatter_js_options":

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Language specific options:
         "passes": [],
 
         // Disable specific transformations
-        "exclude": []
+        "excludes": []
     }
 ```
 


### PR DESCRIPTION
Updates only the readme and the default config. It's only that the plugin expects the word to be "excludes" but the default config and the readme had "exclude" like the config on phpfmt.

Do I leave it like this or do you want to adhere to the wording on the phpfmt package?

```python
if len(excludes) > 0:
            cmd.append("--exclude="+','.join(excludes))
```