### PR TITLE
fix basestring error

### DIFF
--- a/codeformatter/formatter.py
+++ b/codeformatter/formatter.py
@@ -68,7 +68,7 @@ class Formatter:
 
         for name, _class in map_settings_formatter:
             syntaxes = self.settings.get(name, {}).get('syntaxes')
-            if not syntaxes or not isinstance(syntaxes, basestring):
+            if not syntaxes or not isinstance(syntaxes, str):
                 continue
             for _formatter in syntaxes.split(','):
                 self.classmap[_formatter.strip()] = _class


### PR DESCRIPTION
I guess running unit tests in a python environment is very different from running the code inside sublime. My last PR introduced an error when I test if the value is a basestring instance.
Sorry about that guys. Here is the fix.