### PR TITLE
refactored tests and changed to run on python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - 2.7
+  - 3.3
 
 cache: pip
 

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -1,6 +1,2 @@
-funcsigs==1.0.2
-mock==2.0.0
-pbr==3.1.1
 py==1.4.34
-pytest==3.2.2
-six==1.11.0
+pytest==3.2.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import Mock
+
+
+@pytest.fixture
+def php_view():
+    mview = Mock()
+    mview.return_value.settings = Mock(return_value={'syntax': 'Packages/User/PHP.sublime-syntax'})
+    mview.return_value.file_name = Mock(return_value='php_file_name')
+    return mview()
+
+
+@pytest.fixture
+def invalid_syntax_view():
+    mview = Mock()
+    mview.return_value.settings = Mock(return_value={'syntax': 'invalid_syntax'})
+    mview.return_value.file_name = Mock(return_value='invalid_file_name')
+    return mview()
+
+
+@pytest.fixture
+def default_settings():
+    settings = {
+        'codeformatter_php_options': {'syntaxes': 'php'},
+        'codeformatter_js_options': {'syntaxes': 'javascript,json'},
+        'codeformatter_css_options': {'syntaxes': 'css,less'},
+        'codeformatter_html_options': {'syntaxes': 'html,asp'},
+        'codeformatter_python_options': {'syntaxes': 'python'},
+        'codeformatter_vbscript_options': {'syntaxes': 'vbscript'},
+        'codeformatter_scss_options': {'syntaxes': 'scss'},
+        'codeformatter_coldfusion_options': {'syntaxes': 'coldfusion'}
+    }
+    return settings


### PR DESCRIPTION
Changes:
- refactored tests to use pytest fixtures;
- cleaned python2 requirements;
- changed travis script to run on python 3.3
- implemented new tests for the formatter functions